### PR TITLE
fix: correct broken link, typo, image path, and add alt text

### DIFF
--- a/404.html
+++ b/404.html
@@ -6,7 +6,7 @@ layout: col-generic
 ---
 
 <div class="container">
-  <p><img src="/assets/images/web/404-old-owasp.png"></p>
+  <p><img src="/assets/images/404-old-owasp.png" alt="Page not found"></p>
   <h2>WHOA THAT PAGE CANNOT BE FOUND</h2>
   <p>Try the <strong>SEARCH</strong> function in the main navigation to find something. If you are looking for chapter information, please see <a href="/chapters/">Chapters</a> for the correct chapter. For information about OWASP projects see <a href="/projects/">Projects</a>. For common attacks, vulnerabilities, or information about other community-led contributions see <a href="/www-community/">Contributed Content</a>.</p>
   

--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ country: USA
 
 ### Upcoming Meetings
 
-We schedule our meetings on the OWASP New York [Meetup Group](https://www.meetup.com/OWASP-New-York-City-Chapter/) and [Luma calendar](https://luma.com/owasp-new-yorl-city)
+We schedule our meetings on the OWASP New York [Meetup Group](https://www.meetup.com/OWASP-New-York-City-Chapter/) and [Luma calendar](https://luma.com/owasp-new-york-city)
 
 {% include chapter_events.html group=page.meetup-group %}
 

--- a/info.md
+++ b/info.md
@@ -4,7 +4,7 @@
 * [An overview of OWASP, by Nancy Gariche](https://www.youtube.com/watch?v=XxntPxfJsdE)
 * [Join Our Mailing List](https://groups.google.com/a/owasp.org/d/forum/new-york-chapter)
 * [Chapter Policy](https://owasp.org/www-policy/operational/chapters)
-* [Speaker Agreeement](https://owasp.org/www-policy/legal/speaker-agreement)
+* [Speaker Agreement](https://owasp.org/www-policy/legal/speaker-agreement)
 
 ### Social Links
 

--- a/tab_meetups.md
+++ b/tab_meetups.md
@@ -12,7 +12,7 @@ tags: NYC
 ## OWASP New York City Chapter Meetups and Events
 
 
-![](assets/images/top-meetup-group-of-2025.png)
+![OWASP NYC Chapter - Top Meetup Group of 2025](assets/images/top-meetup-group-of-2025.png)
 
 ----------
 


### PR DESCRIPTION
Closes #8 

Fixes:
- index.md: corrected broken Luma calendar URL (yorl -> york)
- info.md: fixed typo (Agreeement -> Agreement)
- 404.html: fixed broken image path (removed non-existent /web/ directory)
- tab_meetups.md: added descriptive alt text to image